### PR TITLE
Add Cyclone DDS setup, and dependencies for Tiago Pro robot and hand-e gripper

### DIFF
--- a/cyclone.sh
+++ b/cyclone.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Add the RMW_IMPLEMENTATION environment variable to bashrc
+echo 'export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp' >> ~/.bashrc
+
+# Add the echo of the cyclone_config.xml path to bashrc
+echo 'echo $HOME/cyclone_config.xml' >> ~/.bashrc

--- a/cyclone_config.xml
+++ b/cyclone_config.xml
@@ -1,0 +1,31 @@
+<CycloneDDS>
+  <Domain>
+    <General>
+      <AllowMulticast>false</AllowMulticast>
+      <MaxMessageSize>1400B</MaxMessageSize>
+      <Interfaces>
+      	<!-- Note: The name="" must be set in according to ifconfig -->
+        <!-- <NetworkInterface name="enp4s0" priority="1"/> -->
+        <NetworkInterface name="lo" priority="0"/>
+      </Interfaces>
+    </General>
+    <Discovery>
+      <ParticipantIndex>auto</ParticipantIndex>
+      <Peers>
+        <Peer Address="localhost"/>
+        <Peer Address="192.168.254.100"/> <!-- UR10 E 2F-->
+        <!-- <Peer Address=""/> --> <!-- Tiago pro-->
+      </Peers>
+      <MaxAutoParticipantIndex>500</MaxAutoParticipantIndex>
+    </Discovery>
+    <Internal>
+      <Watermarks>
+        <WhcHigh>2000kB</WhcHigh>
+      </Watermarks>
+    </Internal>
+    <Tracing>
+      <Verbosity>config</Verbosity>
+      <OutputFile>${HOME}/.ros/log/cdds.log</OutputFile>
+    </Tracing>
+  </Domain>
+</CycloneDDS>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p /home/$USER_NAME/static/drims2_ws/src
 WORKDIR /home/$USER_NAME/static/drims2_ws/src
 
 # Clone code as root
-RUN git clone https://github.com/SamueleSandrini/drims2_motion_control.git
+RUN git clone https://github.com/CNR-STIIMA-IRAS/drims2_motion_control.git
 RUN vcs import < drims2_motion_control/dependencies.repos
 RUN git clone https://github.com/CNR-STIIMA-IRAS/drims2_dice_simulator.git
 RUN git clone https://github.com/CNR-STIIMA-IRAS/drims2_cells

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y \
     ros-humble-realsense2-camera \
     ros-humble-ur-* \
     ros-humble-omni-base* ros-humble-play-motion2 ros-humble-diagnostic-aggregator ros-humble-gazebo*\
-    libprotobuf-dev protobuf-compiler ros-humble-tf*
+    libprotobuf-dev protobuf-compiler ros-humble-tf* \
+    ros-humble-rmw-cyclonedds-cpp \
+    net-tools iproute2
 
 RUN apt-get install -y python3-pip python3-colcon-common-extensions python3-pybind11 cmake libmodbus-dev libmongoclient-dev wget\
     && wget https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64 -O /usr/bin/yq \
@@ -74,10 +76,15 @@ RUN echo "source /usr/share/gazebo/setup.bash" >> ~/.bashrc
 RUN echo "export LIBGL_ALWAYS_SOFTWARE=1" >> ~/.bashrc
 RUN echo "if [ -f ~/static/drims2_ws/install/setup.bash ]; then source ~/static/drims2_ws/install/setup.bash; fi" >> ~/.bashrc
 
-# Add the check script
+# Configure cyclone configuration to bashrc
+RUN echo "export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp" >> ~/.bashrc
+
+# Add the check script and setup robot connection script to the container
 COPY check_script.sh /home/$USER_NAME/check_script.sh
+COPY setup_robot_connection.sh /home/$USER_NAME/setup_robot_connection.sh
 USER root
 RUN chmod +x /home/$USER_NAME/check_script.sh
+RUN chmod +x /home/$USER_NAME/setup_robot_connection.sh
 
 WORKDIR /home/$USER_NAME
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
     python3-pip \
     libboost-all-dev \
     ros-humble-ros2-control ros-humble-ros2-controllers \
-    ros-humble-moveit ros-humble-depthai-ros \
+    ros-humble-moveit ros-humble-depthai-ros ros-humble-moveit-ros-control-interface \
     ros-humble-behaviortree-cpp* ros-humble-ros-testing freeglut3-dev ros-humble-moveit-resources-* \
     ros-humble-realsense2-camera \
     ros-humble-ur-* \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get install -y python3-pip python3-colcon-common-extensions python3-pybi
     
 
 # Python dependencies
-RUN pip3 install --upgrade scipy depthai trimesh transforms3d
+RUN pip3 install --upgrade scipy depthai trimesh transforms3d ur_rtde
 
 # Create user and group with correct IDs
 ARG GROUP_NAME=drims2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,8 @@ RUN echo 'tzdata tzdata/Areas select Etc' | debconf-set-selections \
 
 # Base tools
 RUN apt-get update && apt-get install -y \
-    build-essential nano tmux iputils-ping gdb cmake git openssl libssl-dev libmysqlclient-dev \
+    build-essential nano tmux iputils-ping gdb cmake git \
+    openssl libssl-dev libmysqlclient-dev xvfb \
     python3-colcon-common-extensions \
     python3-pip \
     libboost-all-dev \
@@ -16,8 +17,10 @@ RUN apt-get update && apt-get install -y \
     ros-humble-moveit ros-humble-depthai-ros \
     ros-humble-behaviortree-cpp* ros-humble-ros-testing freeglut3-dev ros-humble-moveit-resources-* \
     ros-humble-realsense2-camera \
+    ros-humble-ur-* \
+    ros-humble-omni-base* ros-humble-play-motion2 ros-humble-diagnostic-aggregator ros-humble-gazebo*\
     libprotobuf-dev protobuf-compiler ros-humble-tf*
-    
+
 RUN apt-get install -y python3-pip python3-colcon-common-extensions python3-pybind11 cmake libmodbus-dev libmongoclient-dev wget\
     && wget https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64 -O /usr/bin/yq \
     && chmod +x /usr/bin/yq
@@ -65,8 +68,10 @@ WORKDIR /home/$USER_NAME/static/drims2_ws
 SHELL ["/bin/bash", "-c"]
 RUN source /opt/ros/humble/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release #--packages-select drims2_msgs
 
-# Add ROS and workspace to bashrc
+# Add ROS, workspace and Gazebo to bashrc
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
+RUN echo "source /usr/share/gazebo/setup.bash" >> ~/.bashrc
+RUN echo "export LIBGL_ALWAYS_SOFTWARE=1" >> ~/.bashrc
 RUN echo "if [ -f ~/static/drims2_ws/install/setup.bash ]; then source ~/static/drims2_ws/install/setup.bash; fi" >> ~/.bashrc
 
 # Add the check script

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,10 +15,12 @@ RUN apt-get update && apt-get install -y \
     ros-humble-ros2-control ros-humble-ros2-controllers \
     ros-humble-moveit ros-humble-depthai-ros \
     ros-humble-behaviortree-cpp* ros-humble-ros-testing freeglut3-dev ros-humble-moveit-resources-* \
+    ros-humble-realsense2-camera \
     libprotobuf-dev protobuf-compiler ros-humble-tf*
     
-RUN apt-get install -y python3-pip python3-colcon-common-extensions python3-pybind11 cmake
-    
+RUN apt-get install -y python3-pip python3-colcon-common-extensions python3-pybind11 cmake libmodbus-dev libmongoclient-dev wget\
+    && wget https://github.com/mikefarah/yq/releases/download/v4.35.1/yq_linux_amd64 -O /usr/bin/yq \
+    && chmod +x /usr/bin/yq
 
 # Python dependencies
 RUN pip3 install --upgrade scipy depthai trimesh transforms3d ur_rtde
@@ -42,9 +44,10 @@ WORKDIR /home/$USER_NAME/static/drims2_ws/src
 RUN git clone https://github.com/CNR-STIIMA-IRAS/drims2_motion_control.git
 RUN vcs import < drims2_motion_control/dependencies.repos
 RUN git clone https://github.com/CNR-STIIMA-IRAS/drims2_dice_simulator.git
-RUN git clone https://github.com/CNR-STIIMA-IRAS/drims2_cells
-COPY deps.repos drims2_cells/deps.repos
-RUN vcs import < drims2_cells/deps.repos
+RUN git clone https://github.com/CNR-STIIMA-IRAS/drims2_cells.git
+RUN yq 'del(.repositories."abb_libs/abb_librws_2.0", .repositories."abb_libs/abb_omnicore_ros2")' \
+    drims2_cells/deps.repos > drims2_cells/deps.filtered.repos
+RUN vcs import < drims2_cells/deps.filtered.repos
 
 COPY abb_librws_2.0 ./abb_librws_2.0
 COPY abb_omnicore_ros2 ./abb_omnicore_ros2
@@ -58,11 +61,9 @@ RUN chown -R $USER_NAME:$GROUP_NAME /home/$USER_NAME
 USER $USER_NAME
 WORKDIR /home/$USER_NAME/static/drims2_ws
 
-
 # 1st build: just build interfaces and messages
 SHELL ["/bin/bash", "-c"]
 RUN source /opt/ros/humble/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release #--packages-select drims2_msgs
-
 
 # Add ROS and workspace to bashrc
 RUN echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc

--- a/docker/setup_robot_connection.sh
+++ b/docker/setup_robot_connection.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env sh
+# Generates $HOME/cyclone_config.xml for CycloneDDS based on the detected subnet/interface.
+# POSIX sh compatible.
+
+# ========= CONFIG: set fixed peers per robot here =========
+# Space-separated list of peer IPs per robot.
+UR_2F_PEERS="192.168.254.100"          # UR robots on 192.168.254.x
+TIAGO_PEERS="10.68.0.50"               # Tiago robots on 10.68.0.x (EDIT as needed)
+# ==========================================================
+
+UR_PFX="192.168.254."
+TIAGO_PFX="10.68.0."
+
+out_file="${HOME}/cyclone_config.xml"
+
+# Find interface that has an IPv4 on a given prefix (e.g., "192.168.254.")
+find_iface_for_prefix() {
+  pfx="$1"
+  # Sample line: "2: enp4s0    inet 192.168.254.42/24 brd ..."
+  ip -o -4 addr show 2>/dev/null | awk -v pfx="$pfx" '
+    $3 == "inet" {
+      # $4 is like "192.168.254.42/24"
+      split($4, a, "/");
+      if (index(a[1], pfx) == 1) { print $2; exit }
+    }
+  '
+}
+
+# Render peers block as XML lines
+# Args: list of IPs
+render_peers_xml() {
+  for ip in "$@"; do
+    [ -n "$ip" ] && printf '        <Peer Address="%s"/>\n' "$ip"
+  done
+}
+
+UR_IFACE="$(find_iface_for_prefix "$UR_PFX")"
+TIAGO_IFACE="$(find_iface_for_prefix "$TIAGO_PFX")"
+
+ROBOT=""
+IFACE=""
+PEERS_XML=""
+PEER_LIST="" # For ping
+
+if [ -n "$UR_IFACE" ]; then
+  ROBOT="UR robot"
+  IFACE="$UR_IFACE"
+  PEERS_XML="$(printf '        <Peer Address="localhost"/>\n%s' "$(render_peers_xml $UR_2F_PEERS)")"
+  PEER_LIST="$UR_2F_PEERS"   # <-- peers to ping
+elif [ -n "$TIAGO_IFACE" ]; then
+  ROBOT="TIAGO robot"
+  IFACE="$TIAGO_IFACE"
+  PEERS_XML="$(printf '        <Peer Address="localhost"/>\n%s' "$(render_peers_xml $TIAGO_PEERS)")"
+  PEER_LIST="$TIAGO_PEERS"   # <-- peers to ping
+else
+  echo "❌  No known robot subnet detected (neither 192.168.254.* nor 10.68.0.*)."
+  echo "👉  Hint: check 'ip -4 addr' to confirm your assigned addresses."
+  exit 1
+fi
+
+# Backup existing file
+if [ -f "$out_file" ]; then
+  cp -f "$out_file" "${out_file}.bak" 2>/dev/null || true
+fi
+
+# Write template with placeholders. Keep ${HOME} literal using single-quoted heredoc.
+cat > "$out_file" <<'EOF'
+<CycloneDDS>
+  <Domain>
+    <General>
+      <AllowMulticast>false</AllowMulticast>
+      <MaxMessageSize>1400B</MaxMessageSize>
+      <Interfaces>
+        <!-- Note: The name="" must be set according to ip/ifconfig -->
+        <NetworkInterface name="__IFACE__" priority="1"/>
+        <NetworkInterface name="lo" priority="0"/>
+      </Interfaces>
+    </General>
+    <Discovery>
+      <ParticipantIndex>auto</ParticipantIndex>
+      <Peers>
+__PEERS__
+      </Peers>
+      <MaxAutoParticipantIndex>500</MaxAutoParticipantIndex>
+    </Discovery>
+    <Internal>
+      <Watermarks>
+        <WhcHigh>2000kB</WhcHigh>
+      </Watermarks>
+    </Internal>
+    <Tracing>
+      <Verbosity>config</Verbosity>
+      <OutputFile>${HOME}/.ros/log/cdds.log</OutputFile>
+    </Tracing>
+  </Domain>
+</CycloneDDS>
+EOF
+
+# Substitute placeholders (__IFACE__, __PEERS__)
+# Use awk to safely inject multi-line peers XML.
+tmp="$(mktemp 2>/dev/null || echo /tmp/cyclone_cfg.$$)"
+awk -v iface="$IFACE" -v peers="$PEERS_XML" '
+  {
+    if ($0 ~ /__IFACE__/) gsub(/__IFACE__/, iface)
+    if ($0 ~ /__PEERS__/) {
+      sub(/__PEERS__/, "<<<PEERS_PLACEHOLDER>>>")
+    }
+    print
+  }
+' "$out_file" | awk -v peers="$PEERS_XML" '
+  {
+    if ($0 ~ /<<<PEERS_PLACEHOLDER>>>/) {
+      gsub(/<<<PEERS_PLACEHOLDER>>>/, peers)
+    }
+    print
+  }
+' > "$tmp" && mv "$tmp" "$out_file"
+
+echo "✅ Detected connection: $ROBOT on interface '$IFACE'."
+echo "✅ CycloneDDS config written to: $out_file"
+
+# --- Connectivity check (ping) ---
+PING_OK=0
+for peer in $PEER_LIST; do
+  if ping -c 1 -W 1 -I "$IFACE" -q "$peer" >/dev/null 2>&1; then
+    echo "✅ Connectivity: $ROBOT reachable at $peer"
+    PING_OK=1
+    break
+  fi
+done
+[ "$PING_OK" -eq 0 ] && echo "❌ Connectivity: no peers reachable on $ROBOT network"
+
+# === Append to ~/.bashrc if not already present ===
+BASHRC="$HOME/.bashrc"
+EXPORT_LINE='export CYCLONEDDS_URI=$HOME/cyclone_config.xml'
+
+# Check if line already exists
+if ! grep -Fxq "$EXPORT_LINE" "$BASHRC"; then
+    echo "$EXPORT_LINE" >> "$BASHRC"
+    echo "✅ Added export line to $BASHRC"
+fi
+
+. "$HOME/.bashrc"

--- a/docker/setup_robot_connection.sh
+++ b/docker/setup_robot_connection.sh
@@ -5,7 +5,7 @@
 # ========= CONFIG: set fixed peers per robot here =========
 # Space-separated list of peer IPs per robot.
 UR_2F_PEERS="192.168.254.100"          # UR robots on 192.168.254.x
-TIAGO_PEERS="10.68.0.50"               # Tiago robots on 10.68.0.x (EDIT as needed)
+TIAGO_PEERS="10.68.0.1"               # Tiago robots on 10.68.0.x (EDIT as needed)
 # ==========================================================
 
 UR_PFX="192.168.254."

--- a/start.sh
+++ b/start.sh
@@ -2,12 +2,12 @@
 
 # Specify the container name
 CONTAINER_NAME="drims2"
-IMAGE_NAME="smentasti/drims2:2025"
+IMAGE_NAME="cf5f52ef57e3"
 #IMAGE_NAME="my_image"
 
 # Pull the latest image
 echo "Pulling the latest image: $IMAGE_NAME..."
-docker pull $IMAGE_NAME
+#docker pull $IMAGE_NAME
 
 # Grant X permissions
 xhost +si:localuser:$(whoami)
@@ -29,5 +29,22 @@ else
     echo "Container $CONTAINER_NAME does not exist."
 fi
 
-docker run -it  --user drims --privileged -v /dev:/dev -v /dev/bus/usb:/dev/bus/usb --device=/dev/bus/usb --device-cgroup-rule='c 189:* rmw'  -v /etc/udev/rules.d:/etc/udev/rules.d --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --net=host --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume="$(pwd)/drims_ws:/home/drims/drims_ws" --volume="$(pwd)/bags:/home/drims/bags"  --name drims2 -w /home/drims $IMAGE_NAME
+#docker run -it  --user drims --privileged -v /dev:/dev -v /dev/bus/usb:/dev/bus/usb --device=/dev/bus/usb --device-cgroup-rule='c 189:* rmw'  -v /etc/udev/rules.d:/etc/udev/rules.d --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --net=host --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume="$(pwd)/drims_ws:/home/drims/drims_ws" --volume="$(pwd)/bags:/home/drims/bags"  --name drims2 -w /home/drims $IMAGE_NAME
+
+
+docker run -it --privileged --net=host \
+  --user drims \
+  -e DISPLAY=$DISPLAY \
+  -e QT_X11_NO_MITSHM=1 \
+  -e XAUTHORITY=/home/drims/.Xauthority \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+  -v "$XAUTHORITY":/home/drims/.Xauthority:ro \
+  -v /dev:/dev \
+  -v /dev/bus/usb:/dev/bus/usb --device=/dev/bus/usb --device-cgroup-rule='c 189:* rmw' \
+  -v /etc/udev/rules.d:/etc/udev/rules.d \
+  -v "$(pwd)/drims_ws:/home/drims/drims_ws" \
+  -v "$(pwd)/bags:/home/drims/bags" \
+  --name drims2 \
+  -w /home/drims \
+  "$IMAGE_NAME"
 

--- a/start.sh
+++ b/start.sh
@@ -2,12 +2,12 @@
 
 # Specify the container name
 CONTAINER_NAME="drims2"
-IMAGE_NAME="cf5f52ef57e3"
+IMAGE_NAME="smentasti/drims2:2025"
 #IMAGE_NAME="my_image"
 
 # Pull the latest image
 echo "Pulling the latest image: $IMAGE_NAME..."
-#docker pull $IMAGE_NAME
+docker pull $IMAGE_NAME
 
 # Grant X permissions
 xhost +si:localuser:$(whoami)
@@ -29,22 +29,4 @@ else
     echo "Container $CONTAINER_NAME does not exist."
 fi
 
-#docker run -it  --user drims --privileged -v /dev:/dev -v /dev/bus/usb:/dev/bus/usb --device=/dev/bus/usb --device-cgroup-rule='c 189:* rmw'  -v /etc/udev/rules.d:/etc/udev/rules.d --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --net=host --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume="$(pwd)/drims_ws:/home/drims/drims_ws" --volume="$(pwd)/bags:/home/drims/bags"  --name drims2 -w /home/drims $IMAGE_NAME
-
-
-docker run -it --privileged --net=host \
-  --user drims \
-  -e DISPLAY=$DISPLAY \
-  -e QT_X11_NO_MITSHM=1 \
-  -e XAUTHORITY=/home/drims/.Xauthority \
-  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-  -v "$XAUTHORITY":/home/drims/.Xauthority:ro \
-  -v /dev:/dev \
-  -v /dev/bus/usb:/dev/bus/usb --device=/dev/bus/usb --device-cgroup-rule='c 189:* rmw' \
-  -v /etc/udev/rules.d:/etc/udev/rules.d \
-  -v "$(pwd)/drims_ws:/home/drims/drims_ws" \
-  -v "$(pwd)/bags:/home/drims/bags" \
-  --name drims2 \
-  -w /home/drims \
-  "$IMAGE_NAME"
-
+docker run -it  --user drims --privileged -v /dev:/dev -v /dev/bus/usb:/dev/bus/usb --device=/dev/bus/usb --device-cgroup-rule='c 189:* rmw'  -v /etc/udev/rules.d:/etc/udev/rules.d --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --net=host --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume="$(pwd)/drims_ws:/home/drims/drims_ws" --volume="$(pwd)/bags:/home/drims/bags"  --name drims2 -w /home/drims $IMAGE_NAME


### PR DESCRIPTION
This pull request introduces several updates and improvements to support the Tiago Pro robot and unify our DDS configuration across projects:
- Added a pip package for the hand-e gripper.
- Switched to the drims2_motion_server repository.
- Added dependencies required for the Tiago Pro robot.
- Added Cyclone DDS (mandatory for the Tiago robot, so we decided to adopt Cyclone DDS as the unified standard for all the robots). 
- Added a shell script to handle Cyclone DDS configuration setup, useful for detecting the connected robot and loading the corresponding cyclone_config.xml file.

@SMentasti Could you please switch the abb_omnicore_ros2 package to the cari branch in the docker folder? Otherwise, the build fails. Thanks a lot!